### PR TITLE
[FEAT] 내정보 조회 구현

### DIFF
--- a/backend/selection/src/main/java/com/selection/controller/NoticeController.java
+++ b/backend/selection/src/main/java/com/selection/controller/NoticeController.java
@@ -1,7 +1,7 @@
 package com.selection.controller;
 
+import com.selection.dto.PageRequest;
 import com.selection.dto.notice.NoticeResponse;
-import com.selection.dto.notice.PageRequest;
 import com.selection.service.notice.NoticeService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/selection/src/main/java/com/selection/controller/UserController.java
+++ b/backend/selection/src/main/java/com/selection/controller/UserController.java
@@ -1,7 +1,10 @@
 package com.selection.controller;
 
 import com.selection.dto.MyInfoResponse;
+import com.selection.dto.PageRequest;
+import com.selection.dto.article.ArticleResponse;
 import com.selection.security.user.UserService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +19,22 @@ public class UserController {
 
     private final UserService userService;
 
+    @GetMapping("/me")
+    public ResponseEntity<MyInfoResponse> findMyInfo() {
+        MyInfoResponse myInfoResponse = userService.findMyInfo();
+
+        return ResponseEntity.ok()
+            .body(myInfoResponse);
+    }
+
+    @GetMapping("/me/articles")
+    public ResponseEntity<List<ArticleResponse>> findMyArticles(PageRequest pageRequest) {
+        List<ArticleResponse> articles = userService.findMyArticles(pageRequest);
+
+        return ResponseEntity.ok()
+            .body(articles);
+    }
+
     // Todo: 프론트 연결된 이후엔 삭제할 것
     @GetMapping("/oauth2/redirect")
     public ResponseEntity<String> redirectTest(@RequestParam(value = "token", required = true)
@@ -29,13 +48,5 @@ public class UserController {
     public ResponseEntity<String> test() {
         return ResponseEntity.ok()
             .body("메인화면 - 누구나 접근 가능");
-    }
-
-    @GetMapping("/me")
-    public ResponseEntity<MyInfoResponse> findMyInfo() {
-        MyInfoResponse myInfoResponse = userService.findMyInfo();
-
-        return ResponseEntity.ok()
-            .body(myInfoResponse);
     }
 }

--- a/backend/selection/src/main/java/com/selection/controller/UserController.java
+++ b/backend/selection/src/main/java/com/selection/controller/UserController.java
@@ -1,17 +1,25 @@
 package com.selection.controller;
 
+import com.selection.dto.MyInfoResponse;
+import com.selection.security.user.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
+@RequestMapping("/users")
 public class UserController {
+
+    private final UserService userService;
 
     // Todo: 프론트 연결된 이후엔 삭제할 것
     @GetMapping("/oauth2/redirect")
     public ResponseEntity<String> redirectTest(@RequestParam(value = "token", required = true)
-            String token) {
+        String token) {
         return ResponseEntity.ok()
             .body("token : " + token);
     }
@@ -23,10 +31,11 @@ public class UserController {
             .body("메인화면 - 누구나 접근 가능");
     }
 
-    // Todo: 프론트 연결된 이후엔 삭제할 것
-    @GetMapping("/users/me")
-    public ResponseEntity<String> filterTest() {
+    @GetMapping("/me")
+    public ResponseEntity<MyInfoResponse> findMyInfo() {
+        MyInfoResponse myInfoResponse = userService.findMyInfo();
+
         return ResponseEntity.ok()
-            .body("it is your information");
+            .body(myInfoResponse);
     }
 }

--- a/backend/selection/src/main/java/com/selection/dto/MyInfoResponse.java
+++ b/backend/selection/src/main/java/com/selection/dto/MyInfoResponse.java
@@ -1,0 +1,14 @@
+package com.selection.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class MyInfoResponse {
+
+    private String name;
+}

--- a/backend/selection/src/main/java/com/selection/dto/PageRequest.java
+++ b/backend/selection/src/main/java/com/selection/dto/PageRequest.java
@@ -1,6 +1,5 @@
-package com.selection.dto.notice;
+package com.selection.dto;
 
-import lombok.Builder;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 

--- a/backend/selection/src/main/java/com/selection/repository/ArticleRepository.java
+++ b/backend/selection/src/main/java/com/selection/repository/ArticleRepository.java
@@ -1,7 +1,11 @@
 package com.selection.repository;
 
 import com.selection.domain.article.Article;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    Page<Article> findAllById(Pageable pageable, Long id);
 }

--- a/backend/selection/src/main/java/com/selection/security/user/UserService.java
+++ b/backend/selection/src/main/java/com/selection/security/user/UserService.java
@@ -1,18 +1,51 @@
 package com.selection.security.user;
 
+import com.selection.domain.article.Article;
 import com.selection.domain.user.User;
 import com.selection.dto.MyInfoResponse;
+import com.selection.dto.PageRequest;
+import com.selection.dto.article.ArticleResponse;
+import com.selection.repository.ArticleRepository;
+import com.selection.repository.UserRepository;
+import com.selection.security.UserPrincipal;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+@RequiredArgsConstructor
 @Service
 public class UserService {
 
+    private final UserRepository userRepository;
+    private final ArticleRepository articleRepository;
+
     public MyInfoResponse findMyInfo() {
-        User user = (User) SecurityContextHolder.getContext()
+        User me = findMe();
+
+        return new MyInfoResponse(me.getName());
+    }
+
+    /* 이거 인풋 어케받아야하는지? */
+    public List<ArticleResponse> findMyArticles(PageRequest pageRequest) {
+        User me = findMe();
+
+        Page<Article> myArticles = articleRepository.findAllById(pageRequest.of(), me.getId());
+
+        return myArticles.stream()
+            .map(ArticleResponse::new)
+            .collect(Collectors.toList());
+    }
+
+    private User findMe() {
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext()
             .getAuthentication()
             .getPrincipal();
 
-        return new MyInfoResponse(user.getName());
+        Long id = userPrincipal.getId();
+        return userRepository.findById(id)
+            .orElseThrow(() -> new IllegalStateException(id + "는 존재하지 않는 사용자 ID임"));
     }
 }

--- a/backend/selection/src/main/java/com/selection/security/user/UserService.java
+++ b/backend/selection/src/main/java/com/selection/security/user/UserService.java
@@ -1,0 +1,18 @@
+package com.selection.security.user;
+
+import com.selection.domain.user.User;
+import com.selection.dto.MyInfoResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    public MyInfoResponse findMyInfo() {
+        User user = (User) SecurityContextHolder.getContext()
+            .getAuthentication()
+            .getPrincipal();
+
+        return new MyInfoResponse(user.getName());
+    }
+}

--- a/backend/selection/src/main/java/com/selection/service/article/ArticleService.java
+++ b/backend/selection/src/main/java/com/selection/service/article/ArticleService.java
@@ -2,10 +2,10 @@ package com.selection.service.article;
 
 
 import com.selection.domain.article.Article;
+import com.selection.dto.PageRequest;
 import com.selection.dto.article.ArticleLatestResponse;
 import com.selection.dto.article.ArticleRequest;
 import com.selection.dto.article.ArticleResponse;
-import com.selection.dto.notice.PageRequest;
 import com.selection.repository.ArticleRepository;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/backend/selection/src/main/java/com/selection/service/notice/NoticeService.java
+++ b/backend/selection/src/main/java/com/selection/service/notice/NoticeService.java
@@ -1,8 +1,8 @@
 package com.selection.service.notice;
 
 import com.selection.domain.notice.Notice;
+import com.selection.dto.PageRequest;
 import com.selection.dto.notice.NoticeResponse;
-import com.selection.dto.notice.PageRequest;
 import com.selection.repository.NoticeReposiotry;
 import java.util.List;
 import java.util.stream.Collectors;


### PR DESCRIPTION
**이슈번호**
#80 

**작업내용**
1. 내 닉네임 조회
```
curl -H "Authorization: Bearer  토큰" -X GET http://localhost:8080/users/me
```

2. 내가 쓴 글 목록
```
curl -H "Authorization: Bearer  토큰" -X GET "http://localhost:8080/users/me/articles?page=0&size=10&direction=ASC"
```
- page : 몇번째 페이지인지 (0부터 시작)
- size : 한 페이지에 몇 개의 article 들을 보여주는지
- direction : 정렬 기준 (ASC 와 DESC 가 있습니다. 정렬 기준은 글 작성일입니다.)